### PR TITLE
Wait for scroll manager component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plx",
-  "version": "1.3.5",
+  "version": "1.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1337,8 +1337,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
-      "dev": true
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
     },
     "batch": {
       "version": "0.6.1",
@@ -2091,6 +2090,11 @@
         "randombytes": "^2.0.0"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -2166,6 +2170,16 @@
             "regjsparser": "^0.1.4"
           }
         }
+      }
+    },
+    "css-to-react-native": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.2.tgz",
+      "integrity": "sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==",
+      "requires": {
+        "css-color-keywords": "^1.0.0",
+        "fbjs": "^0.8.5",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "css-what": {
@@ -4593,8 +4607,7 @@
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -4655,6 +4668,11 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -4930,8 +4948,7 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
-      "dev": true
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "ignore": {
       "version": "3.3.8",
@@ -7259,8 +7276,7 @@
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
-      "dev": true
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
     },
     "postcss-zindex": {
       "version": "2.2.0",
@@ -7509,6 +7525,11 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
       }
+    },
+    "react-is": {
+      "version": "16.5.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
+      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
     },
     "react-proxy": {
       "version": "1.1.8",
@@ -8509,6 +8530,51 @@
           }
         }
       }
+    },
+    "styled-components": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
+      "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
+      "requires": {
+        "buffer": "^5.0.3",
+        "css-to-react-native": "^2.0.3",
+        "fbjs": "^0.8.16",
+        "hoist-non-react-statics": "^2.5.0",
+        "prop-types": "^15.5.4",
+        "react-is": "^16.3.1",
+        "stylis": "^3.5.0",
+        "stylis-rule-sheet": "^0.0.10",
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "stylis": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
+      "integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9557,11 +9557,6 @@
         "string-width": "^1.0.2 || 2"
       }
     },
-    "window-scroll-manager": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/window-scroll-manager/-/window-scroll-manager-1.1.1.tgz",
-      "integrity": "sha512-IUAwjkH8n88QQmZN60mXiVe/N0H17aXN3wZoUkw7IdGncdk63zQwBCJR3zW4yRk8bVYAAYg4VcOW9rP2nRrwmg=="
-    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "webpack-dev-server",
     "build": "rm -rf ./lib && NODE_ENV=\"production\" babel ./source --out-dir ./lib",
+    "build-win": "rmdir /s /q .\\lib 2>nul & mkdir .\\lib & SET NODE_ENV=\"production\" & .\\node_modules\\.bin\\babel .\\source --out-dir .\\lib",
     "build-docs": "rm -rf ./dist-docs && EXAMPLE=\"true\" NODE_ENV=\"production\" webpack",
     "publish-to-npm": "npm run build && npm publish",
     "publish-docs": "sh publish-docs.sh",
@@ -51,6 +52,7 @@
   "dependencies": {
     "bezier-easing": "^2.1.0",
     "prop-types": "^15.6.1",
+    "styled-components": "^3.4.10",
     "window-scroll-manager": "^1.1.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   "dependencies": {
     "bezier-easing": "^2.1.0",
     "prop-types": "^15.6.1",
-    "styled-components": "^3.4.10",
-    "window-scroll-manager": "^1.1.1"
+    "styled-components": "^3.4.10"
   },
   "peerDependencies": {
     "react": ">=15.6.2",

--- a/source/Plx.js
+++ b/source/Plx.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import BezierEasing from 'bezier-easing';
-// import ScrollManager from 'window-scroll-manager';
 
 // Check if code is running in the browser (important for universal rendering)
 const WINDOW_EXISTS = typeof window !== 'undefined';

--- a/source/Plx.js
+++ b/source/Plx.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import BezierEasing from 'bezier-easing';
-import ScrollManager from 'window-scroll-manager';
+// import ScrollManager from 'window-scroll-manager';
 
 // Check if code is running in the browser (important for universal rendering)
 const WINDOW_EXISTS = typeof window !== 'undefined';
@@ -164,6 +164,7 @@ const PROPS_TO_OMIT = [
   'children',
   'className',
   'freeze',
+  'managerId',
   'parallaxData',
   'style',
   'tagName',
@@ -716,22 +717,25 @@ export default class Plx extends Component {
     // Binding handlers
     this.handleScrollChange = this.handleScrollChange.bind(this);
     this.handleResize = this.handleResize.bind(this);
+    this.handleManagerReady = this.handleManagerReady.bind(this);
 
     this.state = {
       element: null,
       showElement: false,
       plxStateClasses: '',
       plxStyle: {},
+      managerReady: false,
     };
+
+    this.SCROLL_EVENT = `${ props.managerId }-scroll`;
+    this.READY_EVENT = `${ props.managerId }-ready`;
   }
 
   componentDidMount() {
-    // Get scroll manager singleton
-    this.scrollManager = new ScrollManager();
     // Add listeners
-    window.addEventListener('window-scroll', this.handleScrollChange);
+    window.addEventListener(this.SCROLL_EVENT, this.handleScrollChange);
     window.addEventListener('resize', this.handleResize);
-
+    window.addEventListener(this.READY_EVENT, this.handleManagerReady);
     this.update();
   }
 
@@ -742,24 +746,30 @@ export default class Plx extends Component {
   }
 
   componentWillUnmount() {
-    const {
-      scrollManager,
-    } = this.state;
-
-    window.removeEventListener('window-scroll', this.handleScrollChange);
+    window.removeEventListener(this.SCROLL_EVENT, this.handleScrollChange);
     window.removeEventListener('resize', this.handleResize);
+    window.removeEventListener(this.READY_EVENT, this.handleManagerReady);
 
     clearTimeout(this.resizeDebounceTimeoutID);
     this.resizeDebounceTimeoutID = null;
+  }
 
-    if (scrollManager) {
-      scrollManager.removeListener();
-    }
+  handleManagerReady(e) {
+    // receive the refernce to the scroll manager getScrollPosition function
+    // sent with the manager ready event
+    this.getScrollPosition = e.getScrollPosition;
+    this.setState({
+      managerReady: true,
+    });
   }
 
   update(scrollPosition = null) {
-    const currentScrollPosition = scrollPosition === null ?
-      this.scrollManager.getScrollPosition().scrollPositionY : scrollPosition;
+    let currentScrollPosition = 0;
+
+    if (this.state.managerReady) {
+      currentScrollPosition = scrollPosition === null ?
+        this.getScrollPosition().scrollPositionY : scrollPosition;
+    }
 
     const newState = getNewState(
       currentScrollPosition,
@@ -885,6 +895,7 @@ Plx.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   freeze: PropTypes.bool,
+  managerId: PropTypes.string.isRequired,
   parallaxData: PropTypes.arrayOf(parallaxDataType),
   style: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])),
   tagName: PropTypes.string,

--- a/source/ScrollManager.jsx
+++ b/source/ScrollManager.jsx
@@ -1,0 +1,107 @@
+/* eslint-disable */
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+// ------------------------------------------------
+// CustomEvent polyfill
+// ------------------------------------------------
+if (typeof window !== 'undefined' && typeof window.CustomEvent !== 'function') {
+    var CustomEventPollyfill = function (event, userParams) {
+        var params = {
+            bubbles: userParams.bubbles || false,
+            cancelable: userParams.cancelable || false,
+            detail: userParams.detail || undefined // eslint-disable-line no-undefined
+        };
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent(event, params.bubbles, params.cancelable, params.detail);
+        return evt;
+    };
+    CustomEventPollyfill.prototype = window.Event.prototype;
+    window.CustomEvent = CustomEventPollyfill;
+}
+
+const ScrollContainer = styled.div`
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow-y: scroll;
+    ::-webkit-scrollbar{
+        display: none;
+    }
+`;
+
+class ScrollManager extends React.Component {
+    constructor(props) {
+        super(props);
+        this.SCROLL_EVENT = `${props.managerId}-scroll`;
+        this.READY_EVENT = `${props.managerId}-ready`;
+        this.ticking = false;
+
+        // bindings
+        this.getScrollPosition = this.getScrollPosition.bind(this);
+        this.handleScroll = this.handleScroll.bind(this);
+    }
+    componentDidMount() {
+        this.scrollTarget.addEventListener('scroll', this.handleScroll);
+        const readyEvent = new CustomEvent(this.READY_EVENT, {
+            getScrollPosition: this.getScrollPosition()
+        });
+
+        // Dispatch the ready event.
+        window.dispatchEvent(readyEvent);
+    }
+    componentWillUnmount() {
+        this.scrollTarget.removeEventListener('scroll', this.handleScroll);
+    }
+    getScrollPosition() {
+        var scrollPositionY = this.scrollTarget.scrollY || this.scrollTarget.scrollTop;
+        var scrollPositionX = this.scrollTarget.scrollX || this.scrollTarget.scrollLeft;
+
+        // Disable overscrolling in safari
+        if (scrollPositionY < 0) {
+            scrollPositionY = 0;
+        }
+        if (scrollPositionX < 0) {
+            scrollPositionX = 0;
+        }
+
+        return {
+            scrollPositionY: scrollPositionY,
+            // Alias for scrollPositionY for backwards compatibility
+            scrollPosition: scrollPositionY,
+            scrollPositionX: scrollPositionX
+        };
+    }
+    handleScroll() {
+        // Fire the event only once per requestAnimationFrame
+        if (!this.ticking) {
+            this.ticking = true;
+            var self = this;
+
+            window.requestAnimationFrame(function () {
+                var event = new CustomEvent(self.SCROLL_EVENT, {
+                    detail: self.getScrollPosition()
+                });
+
+                // Dispatch the event.
+                window.dispatchEvent(event);
+                self.ticking = false;
+            });
+        }
+    }
+    render() {
+        return (
+            <ScrollContainer innerRef={div => { this.scrollTarget = div; }}>
+                {this.props.children}
+            </ScrollContainer>
+        );
+    }
+}
+
+ScrollManager.propTypes = {
+    children: PropTypes.any,
+    managerId: PropTypes.string.isRequired
+}
+
+export default ScrollManager;

--- a/source/index.js
+++ b/source/index.js
@@ -1,4 +1,4 @@
-import ScrollManager from 'window-scroll-manager';
+import ScrollManager from './ScrollManager';
 import Plx from './Plx';
 
 export default Plx;


### PR DESCRIPTION
Changes `ScrollManager` to be a React component instead of the `window-scroll-manager` singleton.  Meant to be a parent component and scroll container for parallax animated `Plx` components, so that the scroll position and info is coming from a `div` instead of `window`.  Timing problems whereby `Plx` components try to access `ScrollManager` functions before the `ScrollManager` is mounted and fully ready are addressed by adding a `MANAGER_READY` event that the `Plx` components listen for.  Also adds a mandatory `managerId` prop to both components, which is used to create unique event names the theory being that it might be possible to have different parallax "zones" on the same page, with the animations inside each one controlled by their own manager component.